### PR TITLE
add name attribute

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,6 +3,8 @@ from .routers import router
 from .schemas.alert_component import Alert
 from services.component_registry import ComponentRegistry
 
+NAME = "Alert System Plugin"
+DESCRIPTION = "A plugin for the Alert System"
 
 def register_plugin():
     # Register UI components
@@ -13,7 +15,6 @@ def register_plugin():
 def unregister_plugin():
     # Unregister UI components
     ComponentRegistry.unregister_component("Alert")
-
 
 REGISTER = register_plugin
 UNREGISTER = unregister_plugin


### PR DESCRIPTION
This pull request introduces metadata for the plugin and removes an unnecessary blank line in the `__init__.py` file. These changes improve the clarity and organization of the plugin's initialization module.

Metadata additions:

* [`__init__.py`](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR6-R7): Added `NAME` and `DESCRIPTION` constants to define metadata for the plugin.

Code cleanup:

* [`__init__.py`](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cL17): Removed an unnecessary blank line in the `unregister_plugin` function for better readability.

**Related Jira Ticket:** SCRUM-376