### PR TITLE
change api url convention

### DIFF
--- a/routers/alert.py
+++ b/routers/alert.py
@@ -35,7 +35,7 @@ async def handle_alert_unsubscribe(connection: WebSocketConnection):
 async def create_alert(
     alert: AlertRequest,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_alerts"]))
+    user: dict = Depends(check_role(["manage_alerts", "send_alert"]))
 ):
     """Creates a new alert that will be broadcast to all users"""
     message_bus = MessageBus(db)
@@ -54,7 +54,7 @@ async def create_alert(
     return await message_bus.send_notification(notification)
 
 
-@router.get("/high-priority", response_model=List[HighPriorityAlertResponse])
+@router.get("/high-priority/", response_model=List[HighPriorityAlertResponse])
 async def get_high_priority_alerts(
     db: Session = Depends(get_db),
 ):

--- a/routers/alert_template.py
+++ b/routers/alert_template.py
@@ -30,7 +30,7 @@ async def list_templates(
     skip: int = 0,
     limit: int = 100,
     db: Session = Depends(get_db),
-    _: dict = Depends(check_role(["manage_alerts", "send_alert"]))
+    _: dict = Depends(check_role(["manage_alerts"]))
 ):
     """List all alert templates"""
     service = AlertTemplateService(db)
@@ -41,7 +41,7 @@ async def list_templates(
 async def get_template(
     template_id: int,
     db: Session = Depends(get_db),
-    _: dict = Depends(check_role(["manage_alerts", "send_alert"]))
+    _: dict = Depends(check_role(["manage_alerts"]))
 ):
     """Get a specific alert template by ID"""
     service = AlertTemplateService(db)


### PR DESCRIPTION
This pull request includes changes to the role dependencies for several API endpoints in the `routers/alert.py` and `routers/alert_template.py` files, as well as a minor update to a route path. The most important changes involve adjusting role permissions for managing alerts and templates, ensuring appropriate access control.

### Role Dependency Updates:
* [`routers/alert.py`](diffhunk://#diff-8918173dc46ee4f47636a554d7e6805b2ad9bffea484900f9b78929778af74eeL38-R38): Updated the `create_alert` endpoint to allow users with the `send_alert` role in addition to the `manage_alerts` role.
* [`routers/alert_template.py`](diffhunk://#diff-6fd63dc50c95d5f8a5d994050e39ff8a12268fa13100ae90c214ad077c2d122dL33-R33): Adjusted the `list_templates` and `get_template` endpoints to restrict access to users with only the `manage_alerts` role, removing the `send_alert` role dependency. [[1]](diffhunk://#diff-6fd63dc50c95d5f8a5d994050e39ff8a12268fa13100ae90c214ad077c2d122dL33-R33) [[2]](diffhunk://#diff-6fd63dc50c95d5f8a5d994050e39ff8a12268fa13100ae90c214ad077c2d122dL44-R44)

### Route Path Update:
* [`routers/alert.py`](diffhunk://#diff-8918173dc46ee4f47636a554d7e6805b2ad9bffea484900f9b78929778af74eeL57-R57): Added a trailing slash to the `/high-priority` route path to standardize the endpoint.

**Related Jira Ticket:** SCRUM-334