### PR TITLE
feat: add pyproject.toml manifest and simplify plugin init

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,22 +1,11 @@
-from coffeebreak import Router
 from .routers import router
 from .schemas.alert_component import Alert
 from coffeebreak import ComponentRegistry
 
-NAME = "Alert System Plugin"
-DESCRIPTION = "A plugin for the Alert System"
 
-def register_plugin():
-    # Register UI components
+def REGISTER():
     ComponentRegistry.register_component(Alert)
-    return router
 
 
-def unregister_plugin():
-    # Unregister UI components
+def UNREGISTER():
     ComponentRegistry.unregister_component("Alert")
-
-REGISTER = register_plugin
-UNREGISTER = unregister_plugin
-
-CONFIG_PAGE = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.coffeebreak]
+identifier = "alert-system-plugin"
+name = "Alert System Plugin"
+description = "A plugin for the Alert System"
+config_page = true


### PR DESCRIPTION
## Summary
- Added `pyproject.toml` with `[tool.coffeebreak]` manifest for plugin metadata
- Simplified `__init__.py` — removed metadata constants and unused imports
- Metadata is now handled by the core automatically via the manifest